### PR TITLE
typescript lsp update

### DIFF
--- a/.config/nvim/lua/plugins/init.lua
+++ b/.config/nvim/lua/plugins/init.lua
@@ -99,7 +99,7 @@ return {
 					"go-debug-adapter",
 
 					-- javascript/typescript & vue
-					"tsserver",
+					"ts_ls",
 					"eslint",
 					"volar",
 					"prettier",


### PR DESCRIPTION
typescript lsp has been changed to be ts_ls. this updates the nvim config to fix mason install issues